### PR TITLE
Do not run the CI on each PR

### DIFF
--- a/.github/workflows/deploy-default-cloud.yaml
+++ b/.github/workflows/deploy-default-cloud.yaml
@@ -2,13 +2,11 @@
 name: Deploy a cluster with defaults
 
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-    - configs/default-cloud.yaml
-    - provision.sh
-
+  # Our quotas in Github actions is low, so we can't run this job
+  # for each PR.
+  release:
+    types:
+      - created
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We don't have enough Github Actions quotas for our free account, so
let's just run the job when preparing a new release.
