### PR TITLE
provision.sh: support RHEL

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -206,7 +206,7 @@ EOF
 # Workaround, it doesn't seem to work fine for now when running
 # the Ansible task that does it in dev-install from Github CI
 echo "DEBUG: Upgrading the server to CentOS Stream..."
-ssh -o ConnectTimeout=10 -o "StrictHostKeyChecking=no" -i $WORK_DIR/ssh-private.key $SERVER_USER@$PUBLIC_IP "rpm --query centos-stream-release || bash -c 'sudo dnf -y swap centos-linux-repos centos-stream-repos && sudo dnf -y distro-sync'"
+ssh -o ConnectTimeout=10 -o "StrictHostKeyChecking=no" -i $WORK_DIR/ssh-private.key $SERVER_USER@$PUBLIC_IP "if test -f /etc/centos-release; then rpm --query centos-stream-release || bash -c 'sudo dnf -y swap centos-linux-repos centos-stream-repos && sudo dnf -y distro-sync'; fi"
 echo "DEBUG: Run dev-install to deploy OpenStack on $CLUSTER_NAME..."
 make osp_full
 echo "DEBUG: Cluster $CLUSTER_NAME was successfuly deployed !"


### PR DESCRIPTION
Do not try to upgrade to CentOS stream if the host is not running
CentOS (e.g. RHEL).
