### PR TITLE
Containerfile: Fix bash syntax in Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -10,12 +10,14 @@ RUN dnf update -y && \
     ansible make && \
     dnf clean all && rm -rf /var/cache/dnf/*
 
-RUN mkdir -p /src/dev-install \
-	&& curl -sSL $dev_install_url \
-	| tee dev-install.tar.gz \
-	| sha256sum -c <(printf "%s  -" "$dev_install_sha256") \
-	&& tar xzvf dev-install.tar.gz --strip=1 -C /src/dev-install/ \
-	&& rm dev-install.tar.gz
+RUN bash -c '\
+	mkdir -p /src/dev-install \
+		&& curl -sSL $dev_install_url \
+		| tee dev-install.tar.gz \
+		| sha256sum -c <(printf "%s  -" "$dev_install_sha256") \
+		&& tar xzvf dev-install.tar.gz --strip=1 -C /src/dev-install/ \
+		&& rm dev-install.tar.gz \
+	'
 
 RUN chown --recursive $default_user /src
 USER $default_user


### PR DESCRIPTION
Bash syntax is not allowed in the Containerfiles (nor in Dockerfiles);
invoking bash to interpret process substitution.

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/18838/rehearse-18838-pull-ci-shiftstack-ci-configs-main-images/1399704333196464128