### PR TITLE
default-cloud: remove ceph device & set local cloudname

### DIFF
--- a/configs/default-cloud.yaml
+++ b/configs/default-cloud.yaml
@@ -1,3 +1,1 @@
-control_plane_ip: 38.129.56.112
-ceph_devices:
-  - /dev/sdc
+local_cloudname: default-cloud


### PR DESCRIPTION
default-cloud is a config that will be used to deploy a cloud with CI
defaults, but we want to be cloud agnostic (can be run in PSI,
VEXXHOST, etc) so we don't want to hardcode Ceph options.
Also we don't need the control plane IP, since we now separate it from the public network.