### PR TITLE
provision.sh: add SoS CI folks to SSH authorized keys

### DIFF
--- a/configs/kuryr-cloud.yaml
+++ b/configs/kuryr-cloud.yaml
@@ -9,8 +9,5 @@ hostname: kuryr-cloud
 clouddomain: ci.vexxhost.ca
 ceph_devices:
   - /dev/sdc
-authorized_keys:
-  - https://github.com/EmilienM.keys
-  - https://github.com/MaysaMacedo.keys
 local_cloudname: kuryr-cloud
 rhsm_enabled: true

--- a/provision.sh
+++ b/provision.sh
@@ -239,6 +239,12 @@ ssl_ca_cert: |
 $INDENTED_SSL_CA_CERT
 ssl_ca_key: |
 $INDENTED_SSL_CA_KEY
+authorized_keys:
+  - https://github.com/EmilienM.keys
+  - https://github.com/MaysaMacedo.keys
+  - https://github.com/mandre.keys
+  - https://github.com/mdbooth.keys
+  - https://github.com/pierreprinetti.keys
 EOF
 
 # If the host is RHEL we'll need credentials to pull images


### PR DESCRIPTION
To facilitate the maintenance of CI servers, by default let's add a few
people from our team. We can add more later if needed.
