### PR TITLE
provision.sh: change defaults to deploy OSP16.1 on RHEL 8.2

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -51,11 +51,11 @@ REDHAT_RHSM_ACTIVATION_KEY=${REDHAT_RHSM_ACTIVATION_KEY:-}
 ######################
 # Note that defaults are set to use our VEXXHOST cloud
 # but they can be overriden to deploy somewhere else (e.g. PSI)
-IMAGE_NAME=${IMAGE_NAME:-centos-8-baremetal}
+IMAGE_NAME=${IMAGE_NAME:-rhel-8.2-x86_64}
 FLAVOR_NAME=${FLAVOR_NAME:-b1-standard-96}
 NETWORK_NAME=${NETWORK_NAME:-public}
 KEYPAIR_NAME=${KEYPAIR_NAME:-shiftstack-ci}
-SERVER_USER=${SERVER_USER:-centos}
+SERVER_USER=${SERVER_USER:-cloud-user}
 OVERRIDE_OS_CLOUD=${OVERRIDE_OS_CLOUD:-}
 
 ######################


### PR DESCRIPTION
Change the environment variables default so we deploy the RHEL 8.2
image (with cloud-user user) instead of CentOS 8.

Indeed, we decided to deploy our CI clouds on OSP 16.1 which is more
realistic & stable from what our clients use.
