### PR TITLE
configs: automate floating ip network creation

### DIFF
--- a/configs/kuryr-cloud.yaml
+++ b/configs/kuryr-cloud.yaml
@@ -8,3 +8,7 @@ clouddomain: ci.vexxhost.ca
 ceph_devices:
   - /dev/sdc
 rhsm_enabled: true
+external_cidr: 38.129.56.0/24
+external_fip_pool_start: 38.129.56.2
+external_fip_pool_end: 38.129.56.42
+external_gateway: 38.129.56.1

--- a/configs/osp-central.yaml
+++ b/configs/osp-central.yaml
@@ -4,3 +4,7 @@ ceph_devices:
 manila_enabled: true
 dcn_az: central
 rhsm_enabled: true
+external_cidr: 38.129.56.0/24
+external_fip_pool_start: 38.129.56.43
+external_fip_pool_end: 38.129.56.83
+external_gateway: 38.129.56.1


### PR DESCRIPTION
Since our provider gives us /24 for floating IPs we decided to give 40
floating IPs per cluster, so let's automate the creation of the
external network directly in dev-install by setting the right
parameters.
