### PR TITLE
Remove automation of fips network creation

### DIFF
--- a/configs/kuryr-cloud.yaml
+++ b/configs/kuryr-cloud.yaml
@@ -8,7 +8,3 @@ clouddomain: ci.vexxhost.ca
 ceph_devices:
   - /dev/sdc
 rhsm_enabled: true
-external_cidr: 38.129.56.0/24
-external_fip_pool_start: 38.129.56.2
-external_fip_pool_end: 38.129.56.42
-external_gateway: 38.129.56.1

--- a/configs/osp-central.yaml
+++ b/configs/osp-central.yaml
@@ -4,7 +4,3 @@ ceph_devices:
 manila_enabled: true
 dcn_az: central
 rhsm_enabled: true
-external_cidr: 38.129.56.0/24
-external_fip_pool_start: 38.129.56.43
-external_fip_pool_end: 38.129.56.83
-external_gateway: 38.129.56.1


### PR DESCRIPTION
The automation of the external network cannot
happens as we need to pre-create the fips
and include as allocation pools. This commit
removes the automation.