### PR TITLE
mecha: set CinderRbdFlattenVolumeFromSnapshot to True

### DIFF
--- a/configs/mecha-az0.yaml
+++ b/configs/mecha-az0.yaml
@@ -12,3 +12,5 @@ hostonly_gateway: 192.168.25.2
 tunnel_remote_ips:
   - 38.102.83.97
 rhsm_enabled: true
+extra_heat_params:
+  CinderRbdFlattenVolumeFromSnapshot: true

--- a/configs/mecha-az1.yaml
+++ b/configs/mecha-az1.yaml
@@ -12,3 +12,5 @@ hostonly_gateway: 192.168.25.3
 tunnel_remote_ips:
   - 38.102.83.97
 rhsm_enabled: true
+extra_heat_params:
+  CinderRbdFlattenVolumeFromSnapshot: true

--- a/configs/mecha-central.yaml
+++ b/configs/mecha-central.yaml
@@ -20,3 +20,5 @@ enabled_services:
 # so we decided to reduce the number of workers to reduce the amount of RAM that will be consumed.
 standalone_extra_config:
   octavia::wsgi::apache:workers: 4
+extra_heat_params:
+  CinderRbdFlattenVolumeFromSnapshot: true


### PR DESCRIPTION
To counter an issue with Cinder snapshot testing with the Kubernetes CSI
driver test suite, we can set this parameter to True and this would
address our problem for now.

Full context is explained here:
https://bugzilla.redhat.com/show_bug.cgi?id=1989680
