### PR TITLE
nfv: add kernel_args for SRIOV

### DIFF
--- a/configs/nfv.yaml
+++ b/configs/nfv.yaml
@@ -54,7 +54,7 @@ dpdk_interface: enp65s0f0
 # Core 29 [22, 70]        [46, 94]       
 # Core 30 [23, 71]        [47, 95]
 #
-kernel_args: "default_hugepagesz=1GB hugepagesz=1G hugepages=384 iommu=pt amd_iommu=on isolcpus=10-23,58-71,34-47,82-95"
+kernel_args: "pci=realloc default_hugepagesz=1GB hugepagesz=1G hugepages=384 iommu=pt amd_iommu=on isolcpus=10-23,58-71,34-47,82-95"
 tuned_isolated_cores: 10-23,58-71,34-47,82-95
 extra_heat_params:
   # We plan to have a maximum of 2 OCP clusters deployed at the same time,


### PR DESCRIPTION
Adding pci=realloc, so the server can create the VFs.
If we don't do that, we get some MMU allocations errors and since we
don't access to the BIOS, we have found this workaround that seems to
work fine.

https://access.redhat.com/solutions/37376
