### PR TITLE
nfv: relax PCI NUMA Affinity Policy

### DIFF
--- a/configs/nfv.yaml
+++ b/configs/nfv.yaml
@@ -107,7 +107,7 @@ post_install: |
   for i in m1.xlarge m1.large.nodisk m1.xlarge.nodisk m1.large m1.medium m1.tiny m1.small; do openstack flavor set --no-property --property hw:mem_page_size=large $i; done
   openstack flavor delete m1.xlarge.nfv
   openstack flavor create --ram 16384 --disk 40 --vcpu 8 --public m1.xlarge.nfv
-  openstack flavor set --property hw:cpu_policy=dedicated --property hw:mem_page_size=large m1.xlarge.nfv
+  openstack flavor set --property hw:cpu_policy=dedicated --property hw:mem_page_size=large --property hw:pci_numa_affinity_policy=preferred m1.xlarge.nfv
   openstack image show centos9-stream || wget https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20220302.0.x86_64.qcow2 && openstack image create --public --disk-format qcow2 --file CentOS-Stream-GenericCloud-9-20220302.0.x86_64.qcow2 centos9-stream && rm -f CentOS-Stream-GenericCloud-9-20220302.0.x86_64.qcow2
   openstack quota set --cores 120 --fixed-ips -1 --injected-file-size -1 --injected-files -1 --instances -1 --key-pairs -1 --properties -1 --ram 450000 --gigabytes 4000 --server-groups -1 --server-group-members -1 --backups -1 --backup-gigabytes -1 --per-volume-gigabytes -1 --snapshots -1 --volumes -1 --floating-ips 80 --secgroup-rules -1 --secgroups -1 --networks -1 --subnets -1 --ports -1 --routers -1 --rbac-policies -1 --subnetpools -1 openshift
   sudo podman create --net=host --name=squid --volume /home/stack/squid/squid.conf:/etc/squid/squid.conf:z --volume /home/stack/squid/htpasswd:/etc/squid/htpasswd:z quay.io/emilien/squid:latest


### PR DESCRIPTION
Use `preferred` policy which is less restrictive and avoid scheduling
issues in our small footprint CI, where we don't have many CPUs to share
between the 2 NUMA nodes.
