### PR TITLE
Adjust MTU for Mecha

### DIFF
--- a/configs/mecha-az0.yaml
+++ b/configs/mecha-az0.yaml
@@ -6,6 +6,8 @@ ephemeral_storage_devices:
 - /dev/sdd
 octavia_enabled: false
 dcn_az: az0
+# https://issues.redhat.com/browse/OCPBUGS-2921
+neutron_mtu: 1400
 local_ip: 192.168.24.10
 control_plane_ip: 192.168.24.11
 hostonly_gateway: 192.168.25.2

--- a/configs/mecha-az1.yaml
+++ b/configs/mecha-az1.yaml
@@ -6,6 +6,8 @@ ephemeral_storage_devices:
 - /dev/sdd
 octavia_enabled: false
 dcn_az: az1
+# https://issues.redhat.com/browse/OCPBUGS-2921
+neutron_mtu: 1400
 local_ip: 192.168.24.20
 control_plane_ip: 192.168.24.21
 hostonly_gateway: 192.168.25.3

--- a/configs/mecha-central.yaml
+++ b/configs/mecha-central.yaml
@@ -6,6 +6,8 @@ ephemeral_storage_devices:
   - /dev/sdc
   - /dev/sdd
 dcn_az: central
+# https://issues.redhat.com/browse/OCPBUGS-2921
+neutron_mtu: 1400
 swiftoperator_enabled: false
 rhsm_enabled: true
 enabled_services:


### PR DESCRIPTION
Vexxhost offers us jumbo frames, so we can go up to 9000 for MTU. Let's
just use 1600 for now, which works for our needs, but we need the tenant
networks to be above the default 1300 because we deploy OCP, which does
double encapsulation with OVN on OVN and with IPv6 it's being
problematic, see https://issues.redhat.com/browse/OCPBUGS-2921
