### PR TITLE
Enable external IPv6 connectivity

### DIFF
--- a/configs/hwoffload.yaml
+++ b/configs/hwoffload.yaml
@@ -89,7 +89,7 @@ post_install: |
   openstack subnet create slaac-v4 --project openshift --subnet-range 10.197.0.0/16 --network slaac-network-v6
   openstack router add subnet dualstack slaac-v6
   openstack router add subnet dualstack slaac-v4
-  openstack router add subnet dualstack external-subnet-v6
+  openstack router set --external-gateway external dualstack
   openstack flavor delete m1.xlarge.nfv
   openstack flavor create --ram 16384 --disk 40 --vcpu 8 --public m1.xlarge.nfv
   openstack flavor set --property hw:cpu_policy=dedicated --property hw:mem_page_size=large m1.xlarge.nfv


### PR DESCRIPTION
In order to access externally the OSP Instances using the IPv6 address, the router must be configured with the dual-stack network set as external gateway.