### PR TITLE
Set shiftstack-prune=keep tag to pre-created resources

### DIFF
--- a/configs/hwoffload.yaml
+++ b/configs/hwoffload.yaml
@@ -95,10 +95,10 @@ post_install: |
   openstack network create --project openshift --share --external --provider-physical-network mellanox-hwoffload --provider-network-type flat mellanox-hwoffload
   openstack subnet create --project openshift mellanox-hwoffload-subnet --subnet-range 192.168.26.0/24 --no-dhcp --gateway 192.168.26.1 --allocation-pool "start=192.168.26.2,end=192.168.26.254" --network mellanox-hwoffload
   for i in m1.xlarge m1.large.nodisk m1.xlarge.nodisk m1.large m1.medium m1.tiny m1.small; do openstack flavor set --no-property --property hw:mem_page_size=large $i; done
-  openstack router create --project openshift dualstack
-  openstack network create --project openshift slaac-network-v6
-  openstack subnet create slaac-v6 --project openshift --subnet-range 2001:db8:2222:5555::/64 --network slaac-network-v6 --ip-version 6 --ipv6-ra-mode slaac --ipv6-address-mode slaac
-  openstack subnet create slaac-v4 --project openshift --subnet-range 10.197.0.0/16 --network slaac-network-v6
+  openstack router create --project openshift --tag shiftstack-prune=keep dualstack
+  openstack network create --project openshift --tag shiftstack-prune=keep slaac-network-v6
+  openstack subnet create slaac-v6 --project openshift --tag shiftstack-prune=keep --subnet-range 2001:db8:2222:5555::/64 --network slaac-network-v6 --ip-version 6 --ipv6-ra-mode slaac --ipv6-address-mode slaac
+  openstack subnet create slaac-v4 --project openshift --tag shiftstack-prune=keep --subnet-range 10.197.0.0/16 --network slaac-network-v6
   openstack router add subnet dualstack slaac-v6
   openstack router add subnet dualstack slaac-v4
   openstack router set --external-gateway external dualstack


### PR DESCRIPTION
There are some pre-created resources in the hwoffload cloud that shouldn't be taken into account when the prune script is ran. This commit sets the tag to those resources to avoid them being cleaned up.