### PR TITLE
OSASINFRA-3551: Updating the NovaComputeCpu Dedicated and Shared Set in nfv config

### DIFF
--- a/configs/nfv.yaml
+++ b/configs/nfv.yaml
@@ -28,15 +28,15 @@ sriov_nova_pci_passthrough:
     physical_network: "mellanox-sriov"
 sriov_nic_numvfs: 8
 dpdk_interface: enp193s0f0
-kernel_args: "default_hugepagesz=1GB hugepagesz=1G hugepages=420 iommu=pt amd_iommu=on isolcpus=10-23,58-71,34-47,82-95"
-tuned_isolated_cores: 10-23,58-71,34-47,82-95
+kernel_args: "default_hugepagesz=1GB hugepagesz=1G hugepages=420 iommu=pt amd_iommu=on isolcpus=15-23,63-71,39-47,87-95"
+tuned_isolated_cores: 15-23,63-71,39-47,87-95
 extra_heat_params:
   CinderRbdFlattenVolumeFromSnapshot: true
-  NovaComputeCpuDedicatedSet: "10-23,58-71,34-47,82-95"
+  NovaComputeCpuDedicatedSet: "16-23,63-71,40-47,87-95"
   NovaReservedHostMemory: 4096
-  NovaComputeCpuSharedSet: "0-9,48-57,24-33,72-81"
+  NovaComputeCpuSharedSet: "0-14,48-62,24-38,72-86"
   OvsDpdkSocketMemory: "2048,2048"
-  OvsPmdCoreList: "10,34"
+  OvsPmdCoreList: "15,38"
   ExtraFirewallRules:
     '168 allow squid':
       dport: 3128

--- a/configs/nfv.yaml
+++ b/configs/nfv.yaml
@@ -29,7 +29,7 @@ sriov_nova_pci_passthrough:
 sriov_nic_numvfs: 8
 dpdk_interface: enp193s0f0
 kernel_args: "default_hugepagesz=1GB hugepagesz=1G hugepages=420 iommu=pt amd_iommu=on isolcpus=15-23,63-71,39-47,87-95"
-tuned_isolated_cores: 15-23,63-71,39-47,87-95
+tuned_isolated_cores: 15-23,64-71,39-47,88-95
 extra_heat_params:
   CinderRbdFlattenVolumeFromSnapshot: true
   NovaComputeCpuDedicatedSet: "16-23,64-71,40-47,88-95"

--- a/configs/nfv.yaml
+++ b/configs/nfv.yaml
@@ -36,7 +36,7 @@ extra_heat_params:
   NovaReservedHostMemory: 4096
   NovaComputeCpuSharedSet: "0-14,48-62,24-38,72-86"
   OvsDpdkSocketMemory: "2048,2048"
-  OvsPmdCoreList: "15,38"
+  OvsPmdCoreList: "15,39"
   ExtraFirewallRules:
     '168 allow squid':
       dport: 3128

--- a/configs/nfv.yaml
+++ b/configs/nfv.yaml
@@ -28,7 +28,7 @@ sriov_nova_pci_passthrough:
     physical_network: "mellanox-sriov"
 sriov_nic_numvfs: 8
 dpdk_interface: enp193s0f0
-kernel_args: "default_hugepagesz=1GB hugepagesz=1G hugepages=420 iommu=pt amd_iommu=on isolcpus=15-23,63-71,39-47,87-95"
+kernel_args: "default_hugepagesz=1GB hugepagesz=1G hugepages=68 iommu=pt amd_iommu=on isolcpus=15-23,64-71,39-47,88-95"
 tuned_isolated_cores: 15-23,64-71,39-47,88-95
 extra_heat_params:
   CinderRbdFlattenVolumeFromSnapshot: true

--- a/configs/nfv.yaml
+++ b/configs/nfv.yaml
@@ -28,6 +28,18 @@ sriov_nova_pci_passthrough:
     physical_network: "mellanox-sriov"
 sriov_nic_numvfs: 8
 dpdk_interface: enp193s0f0
+# We split cores between different pools like so:
+#
+#  0-14: vCPUs
+#    15: OVS-DPDK
+# 16-23: pCPUs
+# 24-38: vCPUs
+#    39: OVS-DPDK
+# 40-47: pCPUs
+# 48-63: vCPUs
+# 64-71: pCPUs
+# 72-87: vCPUs
+# 88-95: pCPUs
 kernel_args: "default_hugepagesz=1GB hugepagesz=1G hugepages=68 iommu=pt amd_iommu=on isolcpus=15-23,64-71,39-47,88-95"
 tuned_isolated_cores: 15-23,64-71,39-47,88-95
 extra_heat_params:

--- a/configs/nfv.yaml
+++ b/configs/nfv.yaml
@@ -32,9 +32,9 @@ kernel_args: "default_hugepagesz=1GB hugepagesz=1G hugepages=420 iommu=pt amd_io
 tuned_isolated_cores: 15-23,63-71,39-47,87-95
 extra_heat_params:
   CinderRbdFlattenVolumeFromSnapshot: true
-  NovaComputeCpuDedicatedSet: "16-23,63-71,40-47,87-95"
+  NovaComputeCpuDedicatedSet: "16-23,64-71,40-47,88-95"
   NovaReservedHostMemory: 4096
-  NovaComputeCpuSharedSet: "0-14,48-62,24-38,72-86"
+  NovaComputeCpuSharedSet: "0-14,48-63,24-38,72-87"
   OvsDpdkSocketMemory: "2048,2048"
   OvsPmdCoreList: "15,39"
   ExtraFirewallRules:


### PR DESCRIPTION
NFV jobs are failing due to insufficient NovaComputeCpuShared cores in the NFV Cloud to deploy controlplane and bootstrap nodes. Changes applied:

- Increasing NovaComputeCpuSharedSet to 60 cores. So isolated_cores (OvsPmdCoreList  + NovaComputeCpuDedicatedSet) will reduced from 56 cores to 36 (allowing at least 4 NFV compute nodes or 4 NFV jobs). 
- Removing the assigned OvsPmdCoreList from the NovaComputeCpuDedicatedSet list. NovaComputeCpuDedicatedSet: Exclude all cores from the OvsPmdCoreList. Pair the sibling threads together. Include all remaining cores.
