### PR TITLE
OSASINFRA-3551: Increase hugepages in NFV config

### DIFF
--- a/configs/nfv.yaml
+++ b/configs/nfv.yaml
@@ -40,7 +40,7 @@ dpdk_interface: enp193s0f0
 # 64-71: pCPUs
 # 72-87: vCPUs
 # 88-95: pCPUs
-kernel_args: "default_hugepagesz=1GB hugepagesz=1G hugepages=68 iommu=pt amd_iommu=on isolcpus=15-23,64-71,39-47,88-95"
+kernel_args: "default_hugepagesz=1GB hugepagesz=1G hugepages=324 iommu=pt amd_iommu=on isolcpus=15-23,64-71,39-47,88-95"
 tuned_isolated_cores: 15-23,64-71,39-47,88-95
 extra_heat_params:
   CinderRbdFlattenVolumeFromSnapshot: true


### PR DESCRIPTION
I realized that the bootstrap machine needs hugepages for NFV cluster deployment. Bootstrap uses the same flavor as Controlplane machines, so masters need a flavor with hugepages; therefore, the hugepage configuration should be the following:

```
16384 / 1024 = 16    # flavour.memory_mb / 1024
16 * ( 5 * 4 ) = 320    # no. hugepages per instance * ( no. instances * no. clusters)
320 + 2 + 2 = 324        # no. hugepages for all instances + no. hugepages for OVS-DPDK
```