### PR TITLE
hwoffload: revert change on m1.small

### DIFF
--- a/configs/hwoffload.yaml
+++ b/configs/hwoffload.yaml
@@ -88,9 +88,6 @@ post_install: |
   openstack router add subnet dualstack slaac-v4
   openstack router set --external-gateway external dualstack
   openstack flavor create --ram 16384 --disk 40 --vcpu 4 --public m1.xlarge.2
-  # for mirror registry we need more space
-  openstack flavor delete m1.small
-  openstack flavor create --ram 2048 --disk 50 --vcpu 1 --ephemeral 1 --public m1.small
   openstack image show centos9-stream || wget https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2 && openstack image create --public --disk-format qcow2 --file CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2 centos9-stream && rm -f CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2
   openstack quota set --cores 120 --fixed-ips -1 --injected-file-size -1 --injected-files -1 --instances -1 --key-pairs -1 --properties -1 --ram 450000 --gigabytes 4000 --server-groups -1 --server-group-members -1 --backups -1 --backup-gigabytes -1 --per-volume-gigabytes -1 --snapshots -1 --volumes -1 --floating-ips 80 --secgroup-rules -1 --secgroups -1 --networks -1 --subnets -1 --ports -1 --routers -1 --rbac-policies -1 --subnetpools -1 openshift
   sudo podman create --net=host --name=squid --volume /home/stack/squid/squid.conf:/etc/squid/squid.conf:z --volume /home/stack/squid/htpasswd:/etc/squid/htpasswd:z quay.io/emilien/squid:latest


### PR DESCRIPTION
We don't need bigger disk anymore since we attach a large cinder volume
used for the mirror registry.
